### PR TITLE
Fix UI scaling and sticky positioning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { Toaster } from "@/components/ui/toaster";
-import { Sidebar } from "@/components/Sidebar";
+import { TopNavigation } from "@/components/Sidebar";
 import { AuthProvider } from "@/components/AuthProvider";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -22,9 +22,9 @@ function App() {
             path="/*"
             element={
               <ProtectedRoute>
-                <div className="flex h-screen bg-zinc-950 text-white">
-                  <Sidebar />
-                  <main className="flex-1 overflow-auto">
+                <div className="min-h-screen bg-zinc-950 text-white">
+                  <TopNavigation />
+                  <main>
                     <Routes>
                                               <Route path="/" element={<Index />} />
                         <Route path="/projects" element={<ProjectList />} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,11 +1,12 @@
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { cn } from "@/lib/utils";
-import { LayoutDashboard, CalendarDays, Calendar, Users, Package, LogOut } from "lucide-react";
+import { LayoutDashboard, CalendarDays, Calendar, Users, Package, LogOut, Menu, X } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { useAuth } from "@/components/AuthProvider";
+import { useState } from "react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -13,6 +14,174 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
+export function TopNavigation() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { session } = useAuth();
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  const isActive = (path: string) => {
+    return location.pathname === path;
+  };
+
+  const handleProjectsClick = () => {
+    queryClient.invalidateQueries({ queryKey: ['projects'] });
+  };
+
+  const handleLogout = async () => {
+    try {
+      await supabase.auth.signOut();
+      navigate('/auth');
+    } catch (error) {
+      toast.error("Failed to sign out");
+    }
+  };
+
+  const handleMobileLinkClick = (onClick?: () => void) => {
+    setIsMobileMenuOpen(false);
+    if (onClick) onClick();
+  };
+
+  const links = [
+    { 
+      href: "/", 
+      label: "Dashboard", 
+      icon: LayoutDashboard,
+      isActive: isActive("/"),
+      onClick: () => {}
+    },
+    { 
+      href: "/projects", 
+      label: "Projects", 
+      icon: CalendarDays,
+      isActive: isActive("/projects"),
+      onClick: handleProjectsClick
+    },
+    { 
+      href: "/planner", 
+      label: "Planner", 
+      icon: Calendar,
+      isActive: isActive("/planner"),
+      onClick: () => {}
+    },
+    { 
+      href: "/crew", 
+      label: "Crew", 
+      icon: Users,
+      isActive: isActive("/crew"),
+      onClick: () => {}
+    },
+    { 
+      href: "/equipment", 
+      label: "Equipment", 
+      icon: Package,
+      isActive: isActive("/equipment"),
+      onClick: () => {}
+    }
+  ];
+
+  return (
+    <nav className="sticky top-0 z-50 bg-zinc-900 border-b border-zinc-800 px-4 md:px-6 py-3">
+      <div className="flex items-center justify-between max-w-screen-2xl mx-auto">
+        {/* Logo */}
+        <div className="flex items-center">
+          <h1 className="text-xl md:text-2xl font-bold text-accent">
+            QUINCY
+          </h1>
+        </div>
+
+        {/* Desktop Navigation Links */}
+        <div className="hidden md:flex items-center space-x-1">
+          {links.map((link) => (
+            <Link
+              key={link.href}
+              to={link.href}
+              onClick={link.onClick}
+              className={cn(
+                "flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-zinc-400 transition-all",
+                "hover:text-zinc-100 hover:bg-zinc-800",
+                link.isActive && "bg-zinc-800 text-zinc-100"
+              )}
+            >
+              <link.icon className="h-4 w-4" />
+              {link.label}
+            </Link>
+          ))}
+        </div>
+
+        {/* Right side - User menu and mobile menu button */}
+        <div className="flex items-center gap-2">
+          {/* User Menu */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button className="flex items-center gap-2 rounded-lg p-2 text-zinc-400 transition-all hover:bg-zinc-800 hover:text-zinc-100">
+                <Avatar className="h-8 w-8">
+                  <AvatarImage 
+                    src={session?.user?.user_metadata?.avatar_url} 
+                    alt={session?.user?.email || 'User avatar'} 
+                  />
+                  <AvatarFallback className="bg-zinc-800 text-zinc-400">
+                    {session?.user?.email?.charAt(0).toUpperCase() || 'U'}
+                  </AvatarFallback>
+                </Avatar>
+                <span className="text-sm font-medium hidden lg:block">
+                  {session?.user?.email?.split('@')[0] || 'User'}
+                </span>
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-[200px]">
+              <DropdownMenuItem 
+                onClick={handleLogout}
+                className="text-red-500 focus:text-red-500 focus:bg-red-500/10"
+              >
+                <LogOut className="mr-2 h-4 w-4" />
+                Sign Out
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          {/* Mobile Menu Button */}
+          <button
+            className="md:hidden rounded-lg p-2 text-zinc-400 transition-all hover:bg-zinc-800 hover:text-zinc-100"
+            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+          >
+            {isMobileMenuOpen ? (
+              <X className="h-5 w-5" />
+            ) : (
+              <Menu className="h-5 w-5" />
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Mobile Navigation Menu */}
+      {isMobileMenuOpen && (
+        <div className="md:hidden border-t border-zinc-800 mt-3 pt-3">
+          <div className="space-y-1">
+            {links.map((link) => (
+              <Link
+                key={link.href}
+                to={link.href}
+                onClick={() => handleMobileLinkClick(link.onClick)}
+                className={cn(
+                  "flex items-center gap-3 rounded-lg px-3 py-3 text-base font-medium text-zinc-400 transition-all",
+                  "hover:text-zinc-100 hover:bg-zinc-800",
+                  link.isActive && "bg-zinc-800 text-zinc-100"
+                )}
+              >
+                <link.icon className="h-5 w-5" />
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </nav>
+  );
+}
+
+// Keep the old Sidebar for backward compatibility (can be removed later)
 export function Sidebar() {
   const location = useLocation();
   const navigate = useNavigate();

--- a/src/components/planner/EquipmentCalendar.tsx
+++ b/src/components/planner/EquipmentCalendar.tsx
@@ -426,8 +426,8 @@ export function EquipmentCalendar({ selectedDate, onDateChange, selectedOwner, v
         </Card>
       ) : (
         <>
-          {/* Sticky Headers - Stick to main page scroll context */}
-          <div className="sticky top-0 z-50 bg-background/95 backdrop-blur-sm border border-border rounded-lg shadow-sm">
+          {/* Sticky Headers - Stick below the navigation bar */}
+          <div className="sticky top-[72px] z-40 bg-background/95 backdrop-blur-sm border border-border rounded-lg shadow-sm">
                 {/* Equipment Planner Title */}
                 <div className="flex items-center gap-2 py-3 px-4 bg-background">
                   <Package className="h-5 w-5 text-green-500" />

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,12 @@
   @apply border-border;
 }
 
+html {
+  font-size: 16px;
+  /* Use zoom instead of transform to avoid breaking sticky positioning */
+  zoom: 0.8;
+}
+
 body {
   @apply bg-background text-foreground font-inter antialiased;
 }


### PR DESCRIPTION
- Add global 80% zoom scaling to reduce overall UI size
- Make top navigation sticky (sticky top-0 z-50)
- Fix sticky positioning for equipment planner headers
- Remove overflow-auto from main container to fix scroll context
- Position equipment headers at top-[72px] to align below nav bar
- Maintain proper z-index layering (nav z-50, headers z-40)