### PR TITLE
Refactor: Improve timeline day highlighting and badge styling

### DIFF
--- a/public/quincy-icon-blue.svg
+++ b/public/quincy-icon-blue.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="64" height="64" fill="#0a0a0a" rx="12"/>
+  
+  <!-- Logo Icon - Interconnected hexagons representing logistics network -->
+  <g transform="translate(12, 12)">
+    <!-- Main hexagon -->
+    <polygon points="20,8 28,12 28,20 20,24 12,20 12,12" 
+             fill="#9b87f5" 
+             stroke="#9b87f5" 
+             stroke-width="1"/>
+    
+    <!-- Connected hexagons -->
+    <polygon points="32,16 36,18 36,22 32,24 28,22 28,18" 
+             fill="none" 
+             stroke="#9b87f5" 
+             stroke-width="2" 
+             opacity="0.7"/>
+    
+    <polygon points="8,16 12,18 12,22 8,24 4,22 4,18" 
+             fill="none" 
+             stroke="#9b87f5" 
+             stroke-width="2" 
+             opacity="0.7"/>
+    
+    <polygon points="20,28 24,30 24,34 20,36 16,34 16,30" 
+             fill="none" 
+             stroke="#9b87f5" 
+             stroke-width="2" 
+             opacity="0.5"/>
+    
+    <!-- Connection lines -->
+    <line x1="26" y1="16" x2="30" y2="18" stroke="#9b87f5" stroke-width="1.5" opacity="0.6"/>
+    <line x1="14" y1="16" x2="10" y2="18" stroke="#9b87f5" stroke-width="1.5" opacity="0.6"/>
+    <line x1="20" y1="22" x2="20" y2="28" stroke="#9b87f5" stroke-width="1.5" opacity="0.4"/>
+  </g>
+</svg>

--- a/public/quincy-icon-orange.svg
+++ b/public/quincy-icon-orange.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="64" height="64" fill="#0a0a0a" rx="12"/>
+  
+  <!-- Logo Icon - Interconnected hexagons representing logistics network -->
+  <g transform="translate(12, 12)">
+    <!-- Main hexagon -->
+    <polygon points="20,8 28,12 28,20 20,24 12,20 12,12" 
+             fill="#F97316" 
+             stroke="#F97316" 
+             stroke-width="1"/>
+    
+    <!-- Connected hexagons -->
+    <polygon points="32,16 36,18 36,22 32,24 28,22 28,18" 
+             fill="none" 
+             stroke="#F97316" 
+             stroke-width="2" 
+             opacity="0.7"/>
+    
+    <polygon points="8,16 12,18 12,22 8,24 4,22 4,18" 
+             fill="none" 
+             stroke="#F97316" 
+             stroke-width="2" 
+             opacity="0.7"/>
+    
+    <polygon points="20,28 24,30 24,34 20,36 16,34 16,30" 
+             fill="none" 
+             stroke="#F97316" 
+             stroke-width="2" 
+             opacity="0.5"/>
+    
+    <!-- Connection lines -->
+    <line x1="26" y1="16" x2="30" y2="18" stroke="#F97316" stroke-width="1.5" opacity="0.6"/>
+    <line x1="14" y1="16" x2="10" y2="18" stroke="#F97316" stroke-width="1.5" opacity="0.6"/>
+    <line x1="20" y1="22" x2="20" y2="28" stroke="#F97316" stroke-width="1.5" opacity="0.4"/>
+  </g>
+</svg>

--- a/public/quincy-logo-blue.svg
+++ b/public/quincy-logo-blue.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="320" height="80" viewBox="0 0 320 80" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="320" height="80" fill="#0a0a0a" rx="8"/>
+  
+  <!-- Logo Icon - Interconnected hexagons representing logistics network -->
+  <g transform="translate(20, 15)">
+    <!-- Main hexagon -->
+    <polygon points="25,10 35,15 35,25 25,30 15,25 15,15" 
+             fill="#9b87f5" 
+             stroke="#9b87f5" 
+             stroke-width="1"/>
+    
+    <!-- Connected hexagons -->
+    <polygon points="40,20 45,22.5 45,27.5 40,30 35,27.5 35,22.5" 
+             fill="none" 
+             stroke="#9b87f5" 
+             stroke-width="2" 
+             opacity="0.7"/>
+    
+    <polygon points="10,20 15,22.5 15,27.5 10,30 5,27.5 5,22.5" 
+             fill="none" 
+             stroke="#9b87f5" 
+             stroke-width="2" 
+             opacity="0.7"/>
+    
+    <polygon points="25,35 30,37.5 30,42.5 25,45 20,42.5 20,37.5" 
+             fill="none" 
+             stroke="#9b87f5" 
+             stroke-width="2" 
+             opacity="0.5"/>
+    
+    <!-- Connection lines -->
+    <line x1="32" y1="20" x2="37" y2="22" stroke="#9b87f5" stroke-width="1.5" opacity="0.6"/>
+    <line x1="18" y1="20" x2="13" y2="22" stroke="#9b87f5" stroke-width="1.5" opacity="0.6"/>
+    <line x1="25" y1="27" x2="25" y2="35" stroke="#9b87f5" stroke-width="1.5" opacity="0.4"/>
+  </g>
+  
+  <!-- QUINCY Text -->
+  <text x="85" y="35" 
+        font-family="Inter, system-ui, sans-serif" 
+        font-size="28" 
+        font-weight="700" 
+        fill="#9b87f5" 
+        letter-spacing="1px">QUINCY</text>
+  
+  <!-- Tagline -->
+  <text x="85" y="52" 
+        font-family="Inter, system-ui, sans-serif" 
+        font-size="11" 
+        font-weight="500" 
+        fill="#9b87f5" 
+        opacity="0.8" 
+        letter-spacing="2px">PRODUCTION LOGISTICS</text>
+</svg>

--- a/public/quincy-logo-orange.svg
+++ b/public/quincy-logo-orange.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="320" height="80" viewBox="0 0 320 80" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="320" height="80" fill="#0a0a0a" rx="8"/>
+  
+  <!-- Logo Icon - Interconnected hexagons representing logistics network -->
+  <g transform="translate(20, 15)">
+    <!-- Main hexagon -->
+    <polygon points="25,10 35,15 35,25 25,30 15,25 15,15" 
+             fill="#F97316" 
+             stroke="#F97316" 
+             stroke-width="1"/>
+    
+    <!-- Connected hexagons -->
+    <polygon points="40,20 45,22.5 45,27.5 40,30 35,27.5 35,22.5" 
+             fill="none" 
+             stroke="#F97316" 
+             stroke-width="2" 
+             opacity="0.7"/>
+    
+    <polygon points="10,20 15,22.5 15,27.5 10,30 5,27.5 5,22.5" 
+             fill="none" 
+             stroke="#F97316" 
+             stroke-width="2" 
+             opacity="0.7"/>
+    
+    <polygon points="25,35 30,37.5 30,42.5 25,45 20,42.5 20,37.5" 
+             fill="none" 
+             stroke="#F97316" 
+             stroke-width="2" 
+             opacity="0.5"/>
+    
+    <!-- Connection lines -->
+    <line x1="32" y1="20" x2="37" y2="22" stroke="#F97316" stroke-width="1.5" opacity="0.6"/>
+    <line x1="18" y1="20" x2="13" y2="22" stroke="#F97316" stroke-width="1.5" opacity="0.6"/>
+    <line x1="25" y1="27" x2="25" y2="35" stroke="#F97316" stroke-width="1.5" opacity="0.4"/>
+  </g>
+  
+  <!-- QUINCY Text -->
+  <text x="85" y="35" 
+        font-family="Inter, system-ui, sans-serif" 
+        font-size="28" 
+        font-weight="700" 
+        fill="#F97316" 
+        letter-spacing="1px">QUINCY</text>
+  
+  <!-- Tagline -->
+  <text x="85" y="52" 
+        font-family="Inter, system-ui, sans-serif" 
+        font-size="11" 
+        font-weight="500" 
+        fill="#F97316" 
+        opacity="0.8" 
+        letter-spacing="2px">PRODUCTION LOGISTICS</text>
+</svg>

--- a/src/components/planner/shared/components/ProjectRow.tsx
+++ b/src/components/planner/shared/components/ProjectRow.tsx
@@ -87,24 +87,14 @@ const ProjectRowComponent = ({
           return (
             <div
               key={dateInfo.date.toISOString()}
-              className={`px-1 relative flex items-center justify-center ${
-                dateInfo.isSelected || dateInfo.isToday ? 'z-10' : ''
-              }`}
+              className="px-1 relative flex items-center justify-center"
               style={{ width: LAYOUT.DAY_CELL_WIDTH }}
             >
-              {/* Today indicator */}
-              {dateInfo.isToday && (
-                <div className="absolute inset-0 bg-gray-500/70 rounded-sm pointer-events-none" />
-              )}
-              {/* Selected indicator */}
-              {dateInfo.isSelected && (
-                <div className="absolute inset-0 border border-gray-300 rounded-sm pointer-events-none" />
-              )}
               
               {/* Data indicator - quantity for equipment, role for crew */}
               {hasData && (
                 <div
-                  className="min-w-[20px] h-5 px-2 rounded-full bg-gray-900 flex items-center justify-center"
+                  className="min-w-[20px] h-5 px-2 rounded-full bg-gray-600 flex items-center justify-center"
                   title={formatPlannerTooltip({
                     date: dateInfo.dateStr,
                     // Crew project row data
@@ -123,7 +113,7 @@ const ProjectRowComponent = ({
                     })
                   })}
                 >
-                  <span className="text-[10px] font-bold text-white leading-none">
+                  <span className="text-xs font-medium text-white leading-[0] text-center" style={{ transform: 'translateY(-0.5px)' }}>
                     {isCrew ? role : quantity}
                   </span>
                 </div>

--- a/src/components/planner/shared/components/TimelineContent.tsx
+++ b/src/components/planner/shared/components/TimelineContent.tsx
@@ -117,6 +117,12 @@ const TimelineContentComponent = ({
     });
   }, [formattedDates, visibleTimelineStart, visibleTimelineEnd]);
 
+  // PERFORMANCE OPTIMIZATION: Pre-calculate problems lookup at top level
+  const problemsLookup = useMemo(() => {
+    if (!warnings?.length) return new Set();
+    return new Set(warnings.map(w => w.resourceId));
+  }, [warnings]);
+
   // Apply UI-level filtering to equipment groups with smart expansion
   const { filteredEquipmentGroups, shouldExpand } = useMemo(() => {
     // Check if any filters are actually active
@@ -132,12 +138,6 @@ const TimelineContentComponent = ({
     const { search, equipmentType, crewRole } = filters || {};
     const isCrewMode = resourceType === 'crew';
     const shouldExpand = new Set<string>();
-    
-    // PERFORMANCE OPTIMIZATION: Use pre-calculated warnings instead of expensive date loops
-    const problemsLookup = useMemo(() => {
-      if (!warnings?.length) return new Set();
-      return new Set(warnings.map(w => w.resourceId));
-    }, [warnings]);
 
     const hasProblems = (item: any) => {
       if (!hasProblemsFilter) {
@@ -263,7 +263,7 @@ const TimelineContentComponent = ({
     filters?.crewRole, 
     resourceType, 
     showProblemsOnly,
-    warnings // PERFORMANCE: Use pre-calculated warnings instead of expensive date loops
+    problemsLookup // PERFORMANCE: Use pre-calculated problems lookup
   ]);
   
   // Auto-expand folders that contain filtered results (only when filters are active)

--- a/src/components/planner/shared/components/TimelineDayCell.tsx
+++ b/src/components/planner/shared/components/TimelineDayCell.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { AlertTriangle, ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { VISUAL, LAYOUT } from '../constants';
 import { EquipmentBookingFlat } from '../types';
 import { formatPlannerTooltip } from '../../../../utils/tooltipFormatters';
@@ -147,23 +147,18 @@ const TimelineDayCellComponent = ({
 
   return (
     <div 
-      className={`equipment-day-cell px-1 relative ${
-        dateInfo.isSelected || dateInfo.isToday ? 'z-10' : ''
-      } flex items-center justify-center`}
+      className="equipment-day-cell px-1 relative flex items-center justify-center"
       style={{ width: LAYOUT.DAY_CELL_WIDTH }}
     >
-      {/* Today indicator - solid blue background */}
-      {dateInfo.isToday && (
-        <div className="absolute inset-0 bg-blue-100/80 rounded pointer-events-none z-10" />
-      )}
-      {/* Selected indicator - solid border overlay */}
-      {dateInfo.isSelected && (
-        <div className="absolute inset-0 border-2 border-blue-300 rounded pointer-events-none z-10" />
-      )}
-      
       {/* Main availability cell - clickable for expansion */}
       <div
-        className="h-6 w-full transition-all duration-200 relative rounded-md border border-gray-200/50 cursor-pointer hover:border-gray-300"
+        className={`h-6 w-full transition-all duration-200 relative rounded-md cursor-pointer ${
+          dateInfo.isToday 
+            ? 'border-2 border-blue-500 hover:border-blue-600' 
+            : dateInfo.isSelected
+            ? 'border-2 border-blue-300 hover:border-blue-400'
+            : 'border border-gray-200/50 hover:border-gray-300'
+        }`}
         title={tooltipText}
         style={heatmapStyle}
         onClick={() => {
@@ -198,10 +193,7 @@ const TimelineDayCellComponent = ({
             )}
           </span>
           
-          {/* Conflict/Overbooked indicator for both crew and equipment */}
-          {isConflict && (
-            <AlertTriangle className="absolute top-0 right-0 h-2 w-2 text-white opacity-80" />
-          )}
+
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Replace heavy absolute overlays with subtle border highlights
- Match day header color scheme (blue-500 for today, blue-300 for selected)
- Remove unnecessary highlighting from project rows
- Standardize badge styling: lighter grey (gray-600), consistent font size (text-xs)
- Improve badge text centering with precise alignment
- Remove bold font from project row badges for cleaner look
- Remove redundant warning triangles from red conflict cells

Result: Much cleaner, more balanced timeline with better visual hierarchy